### PR TITLE
Feature/function enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ in `Get-ProfilePathFromSID`
 
 ### Changed
 
+- Module is now using `WinRegOps` Version `0.4.0` for more refined registry value
+retrieval
+
 - **Get-UserProfilesFromRegistry**: Updated the function to handle scenarios
  where the current user does not have administrative privileges.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ in `Get-ProfilePathFromSID`
 
 ### Changed
 
-- Module is now using `WinRegOps` Version `0.4.0` for more refined registry value
-retrieval
-
 - **Get-UserProfilesFromRegistry**: Updated the function to handle scenarios
  where the current user does not have administrative privileges.
 
@@ -47,6 +44,15 @@ retrieval
 
   - A warning is logged when the fallback method is used, indicating that
    special system accounts are excluded.
+
+- Refactored `Process-RegistryProfiles` to better account for access denied errors
+when testing profile paths with `Test-FolderExists`
+
+- Updated `UserProfile` object creation in `Test-OrphanedProfile` for
+ `$AccessError` Scenarios
+
+- Module is now using `WinRegOps` Version `0.4.0` for more refined registry value
+retrieval
 
 ## [0.2.0] - 2024-09-12
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -20,5 +20,13 @@
     Sampler               = 'latest'
     'Sampler.GitHubTasks' = 'latest'
     'WisherTools.Helpers' = 'latest'
-    'WinRegOps'           = '0.3.0'
+    #'WinRegOps'           = '0.3.0'
+
+    'WinRegOps'           = @{
+        Version    = '0.4.0-preview0001'
+        Parameters = @{
+            AllowPrerelease = $true
+            Repository      = "PSGallery"
+        }
+    }
 }

--- a/source/Private/Get-ProfilePathFromSID.ps1
+++ b/source/Private/Get-ProfilePathFromSID.ps1
@@ -21,7 +21,7 @@ function Get-ProfilePathFromSID
     try
     {
         # Use Get-RegistryValue to retrieve the "ProfileImagePath"
-        $profileImagePath = Get-RegistryValue -Key $SidKey -ValueName "ProfileImagePath"
+        $profileImagePath = Get-RegistryValue -BaseKey $SidKey -ValueName "ProfileImagePath"
 
         if (-not $profileImagePath)
         {

--- a/source/Private/Get-RegistryKeyForSID.ps1
+++ b/source/Private/Get-RegistryKeyForSID.ps1
@@ -24,7 +24,7 @@ function Get-RegistryKeyForSID
     try
     {
         # Use the general Open-RegistrySubKey function to get the subkey for the SID
-        $sidKey = Open-RegistrySubKey -ParentKey $ProfileListKey -SubKeyName $SID
+        $sidKey = Open-RegistrySubKey -BaseKey $ProfileListKey -Name $SID -writable $false
         if ($sidKey -eq $null)
         {
             Write-Warning "The SID '$SID' does not exist in the ProfileList registry."

--- a/source/Private/Get-SIDProfileInfo.ps1
+++ b/source/Private/Get-SIDProfileInfo.ps1
@@ -43,7 +43,7 @@ function Get-SIDProfileInfo
     )
 
     $RegistryPath = "SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
-    $ProfileListKey = Open-RegistryKey -RegistryPath $RegistryPath -ComputerName $ComputerName
+    $ProfileListKey = Open-RegistryKey -RegistryPath $RegistryPath -ComputerName $ComputerName -Writable $false
 
     # Handle null or empty registry key
     if (-not $ProfileListKey)
@@ -70,7 +70,7 @@ function Get-SIDProfileInfo
         }
 
         # Use Open-RegistrySubKey to get the subkey for the SID
-        $subKey = Open-RegistrySubKey -ParentKey $ProfileListKey -SubKeyName $sid
+        $subKey = Open-RegistrySubKey -BaseKey $ProfileListKey -Name $sid -writable $false
 
         if ($subKey -eq $null)
         {
@@ -98,5 +98,3 @@ function Get-SIDProfileInfo
 
     return $ProfileRegistryItems
 }
-
-

--- a/source/Private/Test-FolderExists.ps1
+++ b/source/Private/Test-FolderExists.ps1
@@ -64,6 +64,11 @@ function Test-FolderExists
         # Return whether the path exists
         return Test-Path $pathToCheck
     }
+    catch [UnauthorizedAccessException]
+    {
+        Write-Warning "Access denied when testing folder existence for profile: $ProfilePath. Error: $_"
+        throw
+    }
     catch
     {
         Write-Error "An error occurred: $_"

--- a/source/Private/Test-OrphanedProfile.ps1
+++ b/source/Private/Test-OrphanedProfile.ps1
@@ -9,6 +9,8 @@
     The file path of the profile folder.
 .PARAMETER FolderExists
     Indicates whether the profile folder exists on the computer.
+.PARAMETER AccessError
+    Indicates whether an access error occurred while testing the profile folder.
 .PARAMETER IgnoreSpecial
     Switch to ignore special or default profiles when determining if the profile is orphaned.
 .PARAMETER IsSpecial
@@ -19,28 +21,36 @@
     Test-OrphanedProfile -SID "S-1-5-21-123456789-1001" -ProfilePath "C:\Users\John" -FolderExists $true -IgnoreSpecial -IsSpecial $false -ComputerName "Server01"
     Tests if the profile associated with the given SID is orphaned on "Server01".
 #>
-
 function Test-OrphanedProfile
 {
     param (
         [string]$SID,
         [string]$ProfilePath,
         [bool]$FolderExists,
+        [bool]$AccessError,
         [bool]$IgnoreSpecial,
         [bool]$IsSpecial,
         [string]$ComputerName
     )
 
-    if (-not $ProfilePath)
+    if ($AccessError)
     {
-        return New-UserProfileObject $SID $null $true "MissingProfileImagePath" $ComputerName $IsSpecial
+        return New-UserProfileObject -SID $SID -ProfilePath $ProfilePath -IsOrphaned $false `
+            -OrphanReason "AccessDenied" -ComputerName $ComputerName -IsSpecial $IsSpecial
+    }
+    elseif (-not $ProfilePath)
+    {
+        return New-UserProfileObject -SID $SID -ProfilePath $null -IsOrphaned $true `
+            -OrphanReason "MissingProfileImagePath" -ComputerName $ComputerName -IsSpecial $IsSpecial
     }
     elseif (-not $FolderExists)
     {
-        return New-UserProfileObject $SID $ProfilePath $true "MissingFolder" $ComputerName $IsSpecial
+        return New-UserProfileObject -SID $SID -ProfilePath $ProfilePath -IsOrphaned $true `
+            -OrphanReason "MissingFolder" -ComputerName $ComputerName -IsSpecial $IsSpecial
     }
     else
     {
-        return New-UserProfileObject $SID $ProfilePath $false $null $ComputerName $IsSpecial
+        return New-UserProfileObject -SID $SID -ProfilePath $ProfilePath -IsOrphaned $false `
+            -OrphanReason $null -ComputerName $ComputerName -IsSpecial $IsSpecial
     }
 }

--- a/source/Public/Get-UserProfilesFromRegistry.ps1
+++ b/source/Public/Get-UserProfilesFromRegistry.ps1
@@ -43,18 +43,9 @@ function Get-UserProfilesFromRegistry
             return @()  # Return an empty array
         }
 
-        # If user is an admin, use Get-SIDProfileInfo (Registry-based)
-        if ($ENV:WinProfileOps_IsAdmin -eq $true)
-        {
-            Write-Verbose "User has administrator privileges, using registry-based method."
-            return Get-SIDProfileInfo -ComputerName $ComputerName
-        }
-        else
-        {
-            Write-Warning "User lacks administrator privileges. Switching to fallback method which excludes special accounts from the results."
-            return Get-SIDProfileInfoFallback -ComputerName $ComputerName
-        }
-
+        # Get registry profiles and return them
+        $RegistryProfiles = Get-SIDProfileInfo -ComputerName $ComputerName -ErrorAction Stop
+        return $RegistryProfiles
     }
     catch
     {

--- a/source/ToBeImplimented/RegistryWrapper.ps1
+++ b/source/ToBeImplimented/RegistryWrapper.ps1
@@ -1,0 +1,321 @@
+function Get-DynamicParametersFromMethod
+{
+    param (
+        [Type]$ClassType, # The .NET type of the class, e.g., [Microsoft.Win32.RegistryKey]
+        [string]$MethodName          # The method name to generate parameters for, e.g., "OpenSubKey"
+    )
+
+    # Create dynamic parameters dictionary
+    $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+    # Retrieve methods for the given method name
+    $methods = $ClassType.GetMethods() | Where-Object { $_.Name -eq $MethodName }
+
+    foreach ($method in $methods)
+    {
+        $parameterSetName = $method.ToString()  # Using the method signature as the parameter set name
+
+        # Get parameters for each method overload
+        $parameters = $method.GetParameters()
+
+        foreach ($parameter in $parameters)
+        {
+            # Check if the parameter already exists to avoid duplicates
+            if (-not $paramDictionary.ContainsKey($parameter.Name))
+            {
+                # Create a dynamic parameter for each method parameter
+                $runtimeParam = New-Object System.Management.Automation.RuntimeDefinedParameter(
+                    $parameter.Name, # Parameter name
+                    $parameter.ParameterType, # Type of the parameter
+                    [System.Management.Automation.ParameterAttribute]@{
+                        Mandatory        = $true
+                        ParameterSetName = $parameterSetName   # Bind this parameter to the method overload (parameter set)
+                    }
+                )
+                # Add dynamic parameter to dictionary
+                $paramDictionary.Add($parameter.Name, $runtimeParam)
+            }
+            else
+            {
+                # If parameter exists, just add it to the new parameter set (for overloads)
+                $existingParam = $paramDictionary[$parameter.Name]
+                $paramAttr = New-Object System.Management.Automation.ParameterAttribute
+                $paramAttr.ParameterSetName = $parameterSetName
+                $existingParam.Attributes.Add($paramAttr)
+            }
+        }
+    }
+
+    return $paramDictionary
+}
+function Add-DynamicParameter
+{
+    param (
+        [System.Management.Automation.RuntimeDefinedParameterDictionary]$ParamDictionary,
+        [string[]]$ParameterSetNames,
+        [string]$ParameterName, # Name of the parameter (e.g., 'BaseKey')
+        [Type]$ParameterType = [Microsoft.Win32.RegistryKey], # Type of the parameter (e.g., [Microsoft.Win32.RegistryKey])
+        [bool]$IsMandatory = $true                            # Whether the parameter is mandatory (default is $true)
+    )
+
+    # Define the dynamic parameter attributes
+    $parameterAttributes = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+
+    $paramAttr = New-Object System.Management.Automation.ParameterAttribute
+    $paramAttr.Mandatory = $IsMandatory  # Set whether the parameter is mandatory
+    $parameterAttributes.Add($paramAttr)
+
+    $dynamicParam = New-Object System.Management.Automation.RuntimeDefinedParameter(
+        $ParameterName, # Parameter name
+        $ParameterType, # Parameter type (e.g., [Microsoft.Win32.RegistryKey])
+        $parameterAttributes            # Parameter attributes
+    )
+
+    # Add the dynamic parameter to the dictionary if it doesn't already exist
+    if (-not $ParamDictionary.ContainsKey($ParameterName))
+    {
+        $ParamDictionary.Add($ParameterName, $dynamicParam)
+    }
+
+    # Ensure the parameter is added to each parameter set
+    foreach ($parameterSetName in $ParameterSetNames)
+    {
+        $paramAttrClone = New-Object System.Management.Automation.ParameterAttribute
+        $paramAttrClone.Mandatory = $IsMandatory
+        $paramAttrClone.ParameterSetName = $parameterSetName
+        $ParamDictionary[$ParameterName].Attributes.Add($paramAttrClone)
+    }
+
+    return $ParamDictionary
+}
+function Get-RegistryBaseKey
+{
+    [CmdletBinding()]
+    param (
+
+    )
+
+    DynamicParam
+    {
+        # Get dynamic parameters for the OpenBaseKey method
+        Get-DynamicParametersFromMethod -ClassType ([Microsoft.Win32.RegistryKey]) -MethodName "OpenBaseKey"
+
+    }
+
+    process
+    {
+        try
+        {
+            # Invoke the method overload based on the parameters bound in the dynamic param
+
+            $result = [Microsoft.Win32.RegistryKey]::OpenBaseKey($PSBoundParameters.hkey, $PSBoundParameters.View)
+            <#return [pscustomObject]@{
+                    ParamSets = $PSCmdlet
+                    BoundParam = $PSBoundParameters
+
+                    }#>
+            return $result
+        }
+        catch
+        {
+            throw
+        }
+    }
+}
+function Get-RegistrySubKey
+{
+    [CmdletBinding()]
+    param()
+
+    DynamicParam
+    {
+        # Step 1: Call the helper function to get dynamic parameters for the OpenSubKey method
+        $dynamicParams = Get-DynamicParametersFromMethod -ClassType ([Microsoft.Win32.RegistryKey]) -MethodName "OpenSubKey"
+
+        # Step 2: Extract parameter set names from the dynamic parameters
+        $parameterSetNames = $dynamicParams.Values | ForEach-Object {
+            $_.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } | ForEach-Object { $_.ParameterSetName }
+        } | Select-Object -Unique
+
+        # Step 3: Add additional dynamic parameters using the Add-DynamicParameter function
+
+        # Add 'BaseKey' parameter (mandatory)
+        $dynamicParams = Add-DynamicParameter -ParamDictionary $dynamicParams `
+            -ParameterSetNames $parameterSetNames `
+            -ParameterName 'BaseKey' `
+            -ParameterType ([Microsoft.Win32.RegistryKey]) `
+            -IsMandatory $true
+
+        return $dynamicParams
+    }
+
+    process
+    {
+        # Switch on the ParameterSetName to handle different overloads
+        switch ($PSCmdlet.ParameterSetName)
+        {
+            'Microsoft.Win32.RegistryKey OpenSubKey(System.String, Boolean)'
+            {
+                return $PSBoundParameters.BaseKey.OpenSubKey($PSBoundParameters.Name, $PSBoundParameters.writable)
+            }
+            'Microsoft.Win32.RegistryKey OpenSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck)'
+            {
+                return $PSBoundParameters.BaseKey.OpenSubKey($PSBoundParameters.Name, $PSBoundParameters.permissionCheck)
+            }
+            'Microsoft.Win32.RegistryKey OpenSubKey(System.String, System.Security.AccessControl.RegistryRights)'
+            {
+                return $PSBoundParameters.BaseKey.OpenSubKey($PSBoundParameters.Name, $PSBoundParameters.rights)
+            }
+            'Microsoft.Win32.RegistryKey OpenSubKey(System.String, Microsoft.Win32.RegistryKeyPermissionCheck, System.Security.AccessControl.RegistryRights)'
+            {
+                return $PSBoundParameters.BaseKey.OpenSubKey($PSBoundParameters.Name, $PSBoundParameters.permissionCheck, $PSBoundParameters.rights)
+            }
+            'Microsoft.Win32.RegistryKey OpenSubKey(System.String)'
+            {
+                return $PSBoundParameters.BaseKey.OpenSubKey($PSBoundParameters.Name)
+            }
+            default
+            {
+                throw "Unknown parameter set: $($PSCmdlet.ParameterSetName)"
+            }
+        }
+    }
+}
+
+function Get-RegistrySubKeyNames
+{
+    [CmdletBinding()]
+    param (
+        [Microsoft.Win32.RegistryKey]$SubKey
+    )
+
+    process
+    {
+        try
+        {
+            # Get the subkey names
+            $result = $SubKey.GetSubKeyNames()
+            return $result
+        }
+        catch
+        {
+            throw
+        }
+    }
+}
+function Get-RegistryValueNames
+{
+    [CmdletBinding()]
+    param (
+        [Microsoft.Win32.RegistryKey]$SubKey
+    )
+
+    process
+    {
+        try
+        {
+            # Get the subkey names
+            $result = $SubKey.GetValueNames()
+            return $result
+        }
+        catch
+        {
+            throw
+        }
+    }
+}
+
+function Get-RegistryView
+{
+    [CmdletBinding()]
+    param ()
+
+    DynamicParam
+    {
+        # Create a dynamic parameter dictionary
+        $paramDictionary = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameterDictionary
+
+        # Define the dynamic parameter for RegistryView enum
+        $attribute = New-Object System.Management.Automation.ParameterAttribute
+        $attribute.Mandatory = $true
+
+        # Add the RegistryView enum values as ValidateSet
+        $validateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute([Enum]::GetNames([Microsoft.Win32.RegistryView]))
+
+        # Create the dynamic parameter for RegistryView
+        $paramRegistryView = New-Object System.Management.Automation.RuntimeDefinedParameter(
+            'RegistryView',
+            [Microsoft.Win32.RegistryView],
+            @($attribute, $validateSetAttribute)
+        )
+
+        # Add the parameter to the dictionary
+        $paramDictionary.Add('RegistryView', $paramRegistryView)
+
+        return $paramDictionary
+    }
+
+    process
+    {
+        try
+        {
+            # Return the selected RegistryView value
+            return $PSBoundParameters['RegistryView']
+        }
+        catch
+        {
+            Write-Warning "Error: $_"
+        }
+    }
+}
+function Get-RegistryValue
+{
+    [CmdletBinding()]
+    param()
+
+    DynamicParam
+    {
+        # Step 1: Call the helper function to get dynamic parameters for the OpenSubKey method
+        $dynamicParams = Get-DynamicParametersFromMethod -ClassType ([Microsoft.Win32.RegistryKey]) -MethodName "GetValue"
+
+        # Step 2: Extract parameter set names from the dynamic parameters
+        $parameterSetNames = $dynamicParams.Values | ForEach-Object {
+            $_.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } | ForEach-Object { $_.ParameterSetName }
+        } | Select-Object -Unique
+
+        # Step 3: Add additional dynamic parameters using the Add-DynamicParameter function
+
+        # Add 'BaseKey' parameter (mandatory)
+        $dynamicParams = Add-DynamicParameter -ParamDictionary $dynamicParams `
+            -ParameterSetNames $parameterSetNames `
+            -ParameterName 'BaseKey' `
+            -ParameterType ([Microsoft.Win32.RegistryKey]) `
+            -IsMandatory $true
+
+        return $dynamicParams
+    }
+
+    process
+    {
+        try
+        {
+            return $PSBoundParameters.BaseKey.GetValue($PSBoundParameters.name)
+        }
+        catch
+        {
+            throw
+        }
+    }
+}
+
+
+
+
+
+$RegistryPath = "SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList"
+$BaseKey = Get-RegistryBaseKey -hKey LocalMachine -view Default
+$SubKey = Get-RegistrySubKey -BaseKey $BaseKey -writable $true -Name $RegistryPath
+$sid = Get-RegistrySubKeyNames -SubKey $SubKey
+
+
+Get-RegistryValueNames -SubKey $SubKey

--- a/tests/Unit/Private/Get-SIDProfileInfo.tests.ps1
+++ b/tests/Unit/Private/Get-SIDProfileInfo.tests.ps1
@@ -32,8 +32,8 @@ Describe 'Get-SIDProfileInfo' -Tags 'Private' {
                         }
                     }
                     Mock Open-RegistrySubKey {
-                        param ($ParentKey, $SubKeyName)
-                        if ($SubKeyName -eq 'S-1-5-21-1001')
+                        param ($BaseKey, $Name)
+                        if ($Name -eq 'S-1-5-21-1001')
                         {
                             New-MockObject -Type 'Microsoft.Win32.RegistryKey' -Methods @{
                                 GetValue = { param($valueName) if ($valueName -eq 'ProfileImagePath')
@@ -42,7 +42,7 @@ Describe 'Get-SIDProfileInfo' -Tags 'Private' {
                                     } }
                             } -Properties @{ Name = 'S-1-5-21-1001' }
                         }
-                        elseif ($SubKeyName -eq 'S-1-5-21-1002')
+                        elseif ($Name -eq 'S-1-5-21-1002')
                         {
                             New-MockObject -Type 'Microsoft.Win32.RegistryKey' -Methods @{
                                 GetValue = { param($valueName) if ($valueName -eq 'ProfileImagePath')
@@ -63,7 +63,7 @@ Describe 'Get-SIDProfileInfo' -Tags 'Private' {
                     $result[1].ProfilePath | Should -Be "C:\Users\TestUser2"
 
                     Assert-MockCalled Open-RegistryKey -Exactly 1
-                    Assert-MockCalled Open-RegistrySubKey -Exactly 2
+                    Assert-MockCalled Get-RegistrySubKey -Exactly 2
                     Assert-MockCalled Get-ProfilePathFromSID -Exactly 2
                 }
             }
@@ -83,8 +83,8 @@ Describe 'Get-SIDProfileInfo' -Tags 'Private' {
                         }
                     }
                     Mock Open-RegistrySubKey {
-                        param ($ParentKey, $SubKeyName)
-                        if ($SubKeyName -eq 'S-1-5-21-1001')
+                        param ($BaseKey, $Name)
+                        if ($Name -eq 'S-1-5-21-1001')
                         {
                             return $null
                         }
@@ -234,8 +234,8 @@ Describe 'Get-SIDProfileInfo' -Tags 'Private' {
                         }
                     }
                     Mock Open-RegistrySubKey {
-                        param ($ParentKey, $SubKeyName)
-                        if ($SubKeyName -eq 'S-1-5-21-1001')
+                        param ($BaseKey, $Name)
+                        if ($Name -eq 'S-1-5-21-1001')
                         {
                             New-MockObject -Type 'Microsoft.Win32.RegistryKey' -Methods @{
                                 GetValue = { return 'C:\Users\TestUser1' }

--- a/tests/Unit/Private/New-UserProfileObject.tests.ps1
+++ b/tests/Unit/Private/New-UserProfileObject.tests.ps1
@@ -90,5 +90,29 @@ Describe "New-UserProfileObject" -Tag 'Private' {
                 $result.IsSpecial | Should -Be $isSpecial
             }
         }
+
+        It "Should correctly handle OrphanReason 'AccessDenied'" {
+            InModuleScope -ScriptBlock {
+                # Arrange
+                $sid = "S-1-5-21-123456789-1004"
+                $profilePath = "C:\Users\Jane"
+                $isOrphaned = $false
+                $orphanReason = "AccessDenied"
+                $computerName = "Server01"
+                $isSpecial = $false
+
+                # Act
+                $result = New-UserProfileObject -SID $sid -ProfilePath $profilePath -IsOrphaned $isOrphaned -OrphanReason $orphanReason -ComputerName $computerName -IsSpecial $isSpecial
+
+                # Assert
+                $result.GetType().Name | Should -Be 'UserProfile'
+                $result.SID | Should -Be $sid
+                $result.ProfilePath | Should -Be $profilePath
+                $result.IsOrphaned | Should -Be $isOrphaned
+                $result.OrphanReason | Should -Be $orphanReason
+                $result.ComputerName | Should -Be $computerName
+                $result.IsSpecial | Should -Be $isSpecial
+            }
+        }
     }
 }

--- a/tests/Unit/Private/UserProfileAudit/Process-RegistryProfiles.tests.ps1
+++ b/tests/Unit/Private/UserProfileAudit/Process-RegistryProfiles.tests.ps1
@@ -15,40 +15,55 @@ AfterAll {
 
     # Unload the module being tested so that it doesn't impact any other tests.
     Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Variable -Name capturedParams -Scope Global
 }
 
 Describe 'Process-RegistryProfiles Tests' -Tag 'Private' {
 
     Context 'When processing registry profiles' {
 
-        BeforeEach {
-            # Mock Test-FolderExists to simulate checking if the profile folder exists
-            Mock Test-FolderExists {
-                param ($ProfilePath, $ComputerName)
-                return $true  # Simulate that the folder exists
-            } -ModuleName $script:dscModuleName
-
-            # Mock Test-SpecialAccount to simulate handling of special accounts
-            Mock Test-SpecialAccount {
-                param ($FolderName, $SID, $ProfilePath)
-                return $false  # Simulate that the account is not special
-            } -ModuleName $script:dscModuleName
-
-            # Mock Test-OrphanedProfile to simulate orphaned profile checks
-            Mock Test-OrphanedProfile {
-                param ($SID, $ProfilePath, $FolderExists, $IgnoreSpecial, $IsSpecial, $ComputerName)
-                return [PSCustomObject]@{
-                    SID          = $SID
-                    ProfilePath  = $ProfilePath
-                    IsOrphaned   = -not $FolderExists
-                    ComputerName = $ComputerName
-                    IsSpecial    = $IsSpecial
-                }
-            } -ModuleName $script:dscModuleName
-        }
 
         It 'Should process profiles from the registry' {
             InModuleScope -ScriptBlock {
+                # Mock Test-FolderExists to simulate checking if the profile folder exists
+                Mock Test-FolderExists {
+                    param ($ProfilePath, $ComputerName)
+                    return $true  # Simulate that the folder exists
+                }
+
+                Mock Test-SpecialAccount {
+                    param ($FolderName, $SID, $ProfilePath)
+                    return $false  # Simulate that the account is not special
+                }
+
+                # Update Mock Test-OrphanedProfile to include AccessError parameter
+                Mock Test-OrphanedProfile {
+                    param (
+                        [string]$SID,
+                        [string]$ProfilePath,
+                        [bool]$FolderExists,
+                        [bool]$AccessError,
+                        [bool]$IgnoreSpecial,
+                        [bool]$IsSpecial,
+                        [string]$ComputerName
+                    )
+                    return [PSCustomObject]@{
+                        SID          = $SID
+                        ProfilePath  = $ProfilePath
+                        IsOrphaned   = -not $FolderExists -or $AccessError
+                        OrphanReason = $(if ($AccessError)
+                            {
+                                'AccessDenied'
+                            }
+                            else
+                            {
+                                $null
+                            })
+                        ComputerName = $ComputerName
+                        IsSpecial    = $IsSpecial
+                    }
+                }
 
                 $RegistryProfiles = @(
                     [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = 'C:\Users\User1'; ComputerName = 'Server01' },
@@ -74,11 +89,38 @@ Describe 'Process-RegistryProfiles Tests' -Tag 'Private' {
 
         It 'Should skip special accounts if IgnoreSpecial is set' {
             InModuleScope -ScriptBlock {
-
                 # Mock Test-SpecialAccount to simulate the account is special
                 Mock Test-SpecialAccount {
                     param ($FolderName, $SID, $ProfilePath)
                     return $true  # Simulate that the account is special
+                }
+
+                # Update Mock Test-OrphanedProfile to include AccessError parameter
+                Mock Test-OrphanedProfile {
+                    param (
+                        [string]$SID,
+                        [string]$ProfilePath,
+                        [bool]$FolderExists,
+                        [bool]$AccessError,
+                        [bool]$IgnoreSpecial,
+                        [bool]$IsSpecial,
+                        [string]$ComputerName
+                    )
+                    return [PSCustomObject]@{
+                        SID          = $SID
+                        ProfilePath  = $ProfilePath
+                        IsOrphaned   = -not $FolderExists -or $AccessError
+                        OrphanReason = $(if ($AccessError)
+                            {
+                                'AccessDenied'
+                            }
+                            else
+                            {
+                                $null
+                            })
+                        ComputerName = $ComputerName
+                        IsSpecial    = $IsSpecial
+                    }
                 }
 
                 $RegistryProfiles = @(
@@ -98,11 +140,38 @@ Describe 'Process-RegistryProfiles Tests' -Tag 'Private' {
 
         It 'Should detect orphaned profiles' {
             InModuleScope -ScriptBlock {
-
                 # Mock Test-FolderExists to simulate the folder does not exist
                 Mock Test-FolderExists {
                     param ($ProfilePath, $ComputerName)
                     return $false  # Simulate that the folder does not exist
+                }
+
+                # Update Mock Test-OrphanedProfile to include AccessError parameter
+                Mock Test-OrphanedProfile {
+                    param (
+                        [string]$SID,
+                        [string]$ProfilePath,
+                        [bool]$FolderExists,
+                        [bool]$AccessError,
+                        [bool]$IgnoreSpecial,
+                        [bool]$IsSpecial,
+                        [string]$ComputerName
+                    )
+                    return [PSCustomObject]@{
+                        SID          = $SID
+                        ProfilePath  = $ProfilePath
+                        IsOrphaned   = -not $FolderExists -or $AccessError
+                        OrphanReason = $(if ($AccessError)
+                            {
+                                'AccessDenied'
+                            }
+                            else
+                            {
+                                $null
+                            })
+                        ComputerName = $ComputerName
+                        IsSpecial    = $IsSpecial
+                    }
                 }
 
                 $RegistryProfiles = @(
@@ -120,6 +189,96 @@ Describe 'Process-RegistryProfiles Tests' -Tag 'Private' {
                 # Ensure the mocked functions were called
                 Assert-MockCalled Test-FolderExists -Exactly 1
                 Assert-MockCalled Test-OrphanedProfile -Exactly 1
+            }
+        }
+
+        It 'Should handle access denied errors and continue processing' {
+            InModuleScope -ScriptBlock {
+                # Mock Test-FolderExists to simulate access denied error
+                Mock Test-FolderExists {
+                    Throw [UnauthorizedAccessException]::new('Access is denied.')
+                }
+
+                # Update Mock Test-OrphanedProfile to include AccessError parameter
+                Mock Test-OrphanedProfile {
+                    param (
+                        [string]$SID,
+                        [string]$ProfilePath,
+                        [bool]$FolderExists,
+                        [bool]$AccessError,
+                        [bool]$IgnoreSpecial,
+                        [bool]$IsSpecial,
+                        [string]$ComputerName
+                    )
+                    return [PSCustomObject]@{
+                        SID          = $SID
+                        ProfilePath  = $ProfilePath
+                        IsOrphaned   = -not $FolderExists -or $AccessError
+                        OrphanReason = $(if ($AccessError)
+                            {
+                                'AccessDenied'
+                            }
+                            else
+                            {
+                                $null
+                            })
+                        ComputerName = $ComputerName
+                        IsSpecial    = $IsSpecial
+                    }
+                }
+
+                # Capture parameters passed to Test-OrphanedProfile
+                $global:capturedParams = $null
+
+                # Mock Test-OrphanedProfile to capture parameters
+                Mock Test-OrphanedProfile {
+                    param (
+                        [string]$SID,
+                        [string]$ProfilePath,
+                        [bool]$FolderExists,
+                        [bool]$AccessError,
+                        [bool]$IgnoreSpecial,
+                        [bool]$IsSpecial,
+                        [string]$ComputerName
+                    )
+                    $global:capturedParams = @{
+                        SID           = $SID
+                        ProfilePath   = $ProfilePath
+                        FolderExists  = $FolderExists
+                        AccessError   = $AccessError
+                        IgnoreSpecial = $IgnoreSpecial
+                        IsSpecial     = $IsSpecial
+                        ComputerName  = $ComputerName
+                    }
+                    return [PSCustomObject]@{
+                        SID          = $SID
+                        ProfilePath  = $ProfilePath
+                        IsOrphaned   = $false
+                        OrphanReason = 'AccessDenied'
+                        ComputerName = $ComputerName
+                        IsSpecial    = $IsSpecial
+                    }
+                }
+
+                $RegistryProfiles = @(
+                    [PSCustomObject]@{ SID = 'S-1-5-21-1003'; ProfilePath = 'C:\Users\UserWithAccessError'; ComputerName = 'Server01' }
+                )
+
+                $result = Process-RegistryProfiles -RegistryProfiles $RegistryProfiles -ComputerName 'Server01'
+
+                # Validate result
+                $result | Should -HaveCount 1
+                $result[0].SID | Should -Be 'S-1-5-21-1003'
+                $result[0].ProfilePath | Should -Be 'C:\Users\UserWithAccessError'
+                $result[0].IsOrphaned | Should -Be $false
+                $result[0].OrphanReason | Should -Be 'AccessDenied'
+
+                # Ensure the mocked functions were called
+                Assert-MockCalled Test-FolderExists -Exactly 1
+                Assert-MockCalled Test-OrphanedProfile -Exactly 1
+
+                # Verify that AccessError was set to $true
+                $global:capturedParams.AccessError | Should -Be $true
             }
         }
     }

--- a/tests/Unit/Public/Get-UserProfilesFromRegistry.tests.ps1
+++ b/tests/Unit/Public/Get-UserProfilesFromRegistry.tests.ps1
@@ -28,25 +28,19 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
         BeforeEach {
 
             InModuleScope -ScriptBlock {
-                # Mock Test-ComputerPing to always return true
-                Mock Test-ComputerPing {
-                    return $true
+
+                # Mock Get-SIDProfileInfo to return a list of profiles
+                Mock Get-SIDProfileInfo {
+                    return @(
+                        [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = 'C:\Users\User1' },
+                        [PSCustomObject]@{ SID = 'S-1-5-21-1002'; ProfilePath = 'C:\Users\User2' }
+                    )
                 }
+
             }
         }
 
-        It 'Should return the user profiles from the local registry when user has admin privileges' {
-            # Mock admin environment variable
-            $ENV:WinProfileOps_IsAdmin = $true
-
-            # Mock Get-SIDProfileInfo to return a list of profiles
-            Mock Get-SIDProfileInfo {
-                return @(
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = 'C:\Users\User1' },
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1002'; ProfilePath = 'C:\Users\User2' }
-                )
-            }
-
+        It 'Should return the user profiles from the local registry' {
             $ComputerName = $env:COMPUTERNAME
 
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
@@ -62,45 +56,13 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
             Assert-MockCalled Get-SIDProfileInfo -Exactly 1
             Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
         }
-
-        It 'Should return the user profiles from the local computer using fallback when user lacks admin privileges' {
-            # Mock non-admin environment variable
-            $ENV:WinProfileOps_IsAdmin = $false
-
-            # Mock Get-SIDProfileInfoFallback to return a list of profiles
-            Mock Get-SIDProfileInfoFallback {
-                return @(
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = 'C:\Users\User1' },
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1002'; ProfilePath = 'C:\Users\User2' }
-                )
-            }
-
-            $ComputerName = $env:COMPUTERNAME
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # Validate result
-            $result | Should -HaveCount 2
-            $result[0].SID | Should -Be 'S-1-5-21-1001'
-            $result[0].ProfilePath | Should -Be 'C:\Users\User1'
-            $result[1].SID | Should -Be 'S-1-5-21-1002'
-            $result[1].ProfilePath | Should -Be 'C:\Users\User2'
-
-            # Assert that the fallback method was called
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
-        }
     }
 
     # Test for profiles from a remote computer
     Context 'When retrieving profiles from a remote computer' {
+        BeforeEach {
 
-
-        It 'Should return the user profiles from a remote registry when user has admin privileges' {
             InModuleScope -ScriptBlock {
-                # Mock admin environment variable
-                $ENV:WinProfileOps_IsAdmin = $true
-
                 # Mock Get-SIDProfileInfo to return a list of profiles
                 Mock Get-SIDProfileInfo {
                     return @(
@@ -109,7 +71,9 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
                     )
                 }
             }
+        }
 
+        It 'Should return the user profiles from the remote registry' {
             $ComputerName = 'RemotePC'
 
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
@@ -123,57 +87,24 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
 
             # Assert that Get-SIDProfileInfo was called
             Assert-MockCalled Get-SIDProfileInfo -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1
-        }
-
-        It 'Should return the user profiles from a remote computer when user lacks admin privileges' {
-
-            InModuleScope -ScriptBlock {
-                # Change the environment to simulate non-admin
-                $ENV:WinProfileOps_IsAdmin = $false
-
-                # Mock the fallback method to return profiles
-                Mock Get-SIDProfileInfoFallback {
-                    return @(
-                        [PSCustomObject]@{ SID = 'S-1-5-21-2001'; ProfilePath = 'C:\Users\User1' },
-                        [PSCustomObject]@{ SID = 'S-1-5-21-2002'; ProfilePath = 'C:\Users\User2' }
-                    )
-                }
-            }
-
-            $ComputerName = 'RemotePC'
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # Validate result
-            $result | Should -HaveCount 2
-            $result[0].SID | Should -Be 'S-1-5-21-2001'
-            $result[0].ProfilePath | Should -Be 'C:\Users\User1'
-            $result[1].SID | Should -Be 'S-1-5-21-2002'
-            $result[1].ProfilePath | Should -Be 'C:\Users\User2'
-
-            # Assert that the fallback method was called
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1
+            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
         }
     }
-
 
     # Test when no profiles are found
     Context 'When no profiles are found' {
         BeforeEach {
-            InModuleScope -ScriptBlock {
-                # Mock admin environment variable
-                $ENV:WinProfileOps_IsAdmin = $true
 
+            InModuleScope -ScriptBlock {
                 # Mock Get-SIDProfileInfo to return an empty list
                 Mock Get-SIDProfileInfo {
                     return @()
                 }
+
             }
         }
 
-        It 'Should return an empty result when no profiles are found (admin)' {
+        It 'Should return an empty result when no profiles are found' {
             $ComputerName = $env:COMPUTERNAME
 
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
@@ -183,146 +114,45 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
 
             # Assert that Get-SIDProfileInfo was called
             Assert-MockCalled Get-SIDProfileInfo -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1
-        }
-
-        It 'Should return an empty result when no profiles are found (non-admin)' {
-            # Change the environment to simulate non-admin
-            $ENV:WinProfileOps_IsAdmin = $false
-
-            # Mock the fallback method to return an empty list
-            Mock Get-SIDProfileInfoFallback {
-                return @()
-            } -ModuleName $Script:dscModuleName
-
-            $ComputerName = $env:COMPUTERNAME
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # The result should be empty
-            $result | Should -BeNullOrEmpty
-
-            # Assert that the fallback method was called
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1
+            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
         }
     }
 
-
     # Test when Get-SIDProfileInfo fails
-    Context 'When both registry and fallback profile retrieval methods fail' {
+    Context 'When Get-SIDProfileInfo fails' {
         BeforeEach {
-            InModuleScope -ScriptBlock {
-                # Mock Test-ComputerPing to simulate the computer being online
-                Mock Test-ComputerPing {
-                    return $true
-                }
-
-                # Mock Write-Error to capture the error
-                Mock Write-Error
-            }
-        }
-
-        It 'Should log an error and return nothing when Get-SIDProfileInfo fails (admin)' {
-            # Simulate user has admin privileges
-            $ENV:WinProfileOps_IsAdmin = $true
 
             InModuleScope -ScriptBlock {
-
-                # Mock Write-Error to capture the error
-                Mock Write-Error
-
-                # Mock Test-ComputerPing to simulate the computer being online
-                Mock Test-ComputerPing {
-                    return $true
-                }
-
-                # Mock Get-SIDProfileInfoFallback to simulate an error
-                Mock Get-SIDProfileInfoFallback
-
                 # Mock Get-SIDProfileInfo to simulate an error
                 Mock Get-SIDProfileInfo {
                     throw "Failed to retrieve profiles from the registry"
                 }
 
-            }
-
-            $ComputerName = $env:COMPUTERNAME
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # The result should be empty
-            $result | Should -BeNullOrEmpty
-
-            # Assert that Write-Error was called to log the error
-            Assert-MockCalled Write-Error -Exactly 1
-
-            # Assert that Get-SIDProfileInfo was called once
-            Assert-MockCalled Get-SIDProfileInfo -Exactly 1
-
-            # Assert that Test-ComputerPing was called once
-            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
-
-            # Ensure the fallback function was not called
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 0
-        }
-
-        It 'Should log an error and return nothing when Get-SIDProfileInfoFallback fails (non-admin)' {
-            # Simulate user lacks admin privileges
-            $ENV:WinProfileOps_IsAdmin = $false
-
-            InModuleScope -ScriptBlock {
-
                 # Mock Write-Error to capture the error
                 Mock Write-Error
-
-                # Mock Test-ComputerPing to simulate the computer being online
-                Mock Test-ComputerPing {
-                    return $true
-                }
-
-                # Mock Get-SIDProfileInfoFallback to simulate an error
-                Mock Get-SIDProfileInfoFallback {
-                    throw "Failed to retrieve profiles via fallback method"
-                }
-
-                mock Get-SIDProfileInfo {
-                    return @()
-                }
-
             }
 
 
+        }
 
+        It 'Should log an error and return nothing' {
             $ComputerName = $env:COMPUTERNAME
 
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
 
             # The result should be empty
             $result | Should -BeNullOrEmpty
-
-            # Assert that Write-Error was called to log the error
+            # Assert that Write-Error was called
             Assert-MockCalled Write-Error -Exactly 1
-
-            # Assert that Get-SIDProfileInfoFallback was called once
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-
-            # Assert that Test-ComputerPing was called once
+            Assert-MockCalled Get-SIDProfileInfo -Exactly 1
             Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
-
-            # Ensure the admin function was not called
-            Assert-MockCalled Get-SIDProfileInfo -Exactly 0
         }
     }
-
 
     Context 'When partial profile data is returned' {
         BeforeEach {
             InModuleScope -ScriptBlock {
-                # Mock admin environment variable
-                $ENV:WinProfileOps_IsAdmin = $true
-
-                # Mock Get-SIDProfileInfo to return partial data
+                # Mock Get-SIDProfileInfo to return incomplete profile data
                 Mock Get-SIDProfileInfo {
                     return @(
                         [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = '' }, # Missing profile path
@@ -330,9 +160,11 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
                     )
                 }
             }
+
+
         }
 
-        It 'Should still return the profiles with partial data when user has admin privileges' {
+        It 'Should still return the profiles with partial data' {
             $ComputerName = $env:COMPUTERNAME
 
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
@@ -346,34 +178,7 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
 
             # Assert that Get-SIDProfileInfo was called
             Assert-MockCalled Get-SIDProfileInfo -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1
-        }
-
-        It 'Should still return the profiles with partial data when user lacks admin privileges' {
-            # Change the environment to simulate non-admin
-            $ENV:WinProfileOps_IsAdmin = $false
-
-            # Mock the fallback method to return partial data
-            Mock Get-SIDProfileInfoFallback {
-                return @(
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = '' },
-                    [PSCustomObject]@{ SID = ''; ProfilePath = 'C:\Users\User2' }
-                )
-            } -ModuleName $script:dscModuleName
-
-            $ComputerName = $env:COMPUTERNAME
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # Validate result, even with partial data
-            $result | Should -HaveCount 2
-            $result[0].SID | Should -Be 'S-1-5-21-1001'
-            $result[0].ProfilePath | Should -BeNullOrEmpty
-            $result[1].SID | Should -BeNullOrEmpty
-            $result[1].ProfilePath | Should -Be 'C:\Users\User2'
-
-            # Assert that the fallback method was called
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1
+            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
         }
     }
 
@@ -383,11 +188,6 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
             Mock Test-ComputerPing {
                 return $true
             }
-        }
-
-        It 'Should return profiles when the computer is online and user has admin privileges' {
-            # Mock admin environment variable
-            $ENV:WinProfileOps_IsAdmin = $true
 
             # Mock Get-SIDProfileInfo to return a list of profiles
             Mock Get-SIDProfileInfo {
@@ -397,108 +197,70 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
                 )
             }
 
+        }
+
+        It 'Should return profiles when the computer is online' {
             $result = Get-UserProfilesFromRegistry -ComputerName $env:COMPUTERNAME
 
-            # Validate result
             $result | Should -HaveCount 2
             $result[0].SID | Should -Be 'S-1-5-21-1001'
             $result[1].SID | Should -Be 'S-1-5-21-1002'
 
-            # Assert that Test-ComputerPing and Get-SIDProfileInfo were called
             Assert-MockCalled Test-ComputerPing -Exactly 1
             Assert-MockCalled Get-SIDProfileInfo -Exactly 1
         }
-
-        It 'Should return profiles when the computer is online and user lacks admin privileges' {
-            # Mock non-admin environment variable
-            $ENV:WinProfileOps_IsAdmin = $false
-
-            # Mock Get-SIDProfileInfoFallback to return a list of profiles
-            Mock Get-SIDProfileInfoFallback {
-                return @(
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = 'C:\Users\User1' },
-                    [PSCustomObject]@{ SID = 'S-1-5-21-1002'; ProfilePath = 'C:\Users\User2' }
-                )
-            } -ModuleName $Script:dscModuleName
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $env:COMPUTERNAME
-
-            # Validate result
-            $result | Should -HaveCount 2
-            $result[0].SID | Should -Be 'S-1-5-21-1001'
-            $result[1].SID | Should -Be 'S-1-5-21-1002'
-
-            # Assert that Test-ComputerPing and Get-SIDProfileInfoFallback were called
-            Assert-MockCalled Test-ComputerPing -Exactly 1
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-        }
     }
-
 
     # Test when the computer is offline/unreachable
     Context 'When the computer is offline or unreachable' {
         BeforeEach {
+
+
             InModuleScope -ScriptBlock {
-                # Mock Get-SIDProfileInfo to ensure it is not called
+                # Mock Get-SIDProfileInfo to return incomplete profile data
                 Mock Get-SIDProfileInfo
-                # Mock Get-SIDProfileInfoFallback to ensure it is not called
-                Mock Get-SIDProfileInfoFallback
-
-                # Mock Test-ComputerPing to simulate the computer being offline
-                Mock Test-ComputerPing {
-                    return $false
-                }
-
-                # Mock Write-Warning to capture the warning
-                Mock Write-Warning
             }
+
+            # Mock Test-ComputerPing to simulate the computer being offline
+            Mock Test-ComputerPing {
+                return $false
+            }
+
+            # Mock Write-Warning to capture the warning
+            Mock Write-Warning
         }
 
         It 'Should log a warning and return nothing when the computer is unreachable' {
             $ComputerName = 'OfflinePC'
 
-
-            $env:WinProfileOps_IsAdmin = $true
-
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
 
-            # Validate that the result is empty since the computer is unreachable
             $result | Should -BeNullOrEmpty
-
-            # Assert that Test-ComputerPing was called
             Assert-MockCalled Test-ComputerPing -Exactly 1
-
-            # Assert that Write-Warning was called to log the unreachable computer
             Assert-MockCalled Write-Warning -Exactly 1
-
-            # Assert that neither Get-SIDProfileInfo nor Get-SIDProfileInfoFallback was called
             Assert-MockCalled Get-SIDProfileInfo -Exactly 0
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 0
         }
     }
 
     # Test for profiles when Test-ComputerPing fails
     Context 'When Test-ComputerPing fails' {
+        BeforeEach {
 
-        It 'Should log an error and return nothing when ping fails' {
             InModuleScope -ScriptBlock {
                 # Mock Get-SIDProfileInfo to return incomplete profile data
                 Mock Get-SIDProfileInfo
-
-
-                # Mock Test-ComputerPing to simulate an error or failure
-                Mock Test-ComputerPing {
-                    throw "Ping failed"
-                }
-
             }
 
-            $env:WinProfileOps_IsAdmin = $true
+            # Mock Test-ComputerPing to simulate an error or failure
+            Mock Test-ComputerPing {
+                throw "Ping failed"
+            }
 
             # Mock Write-Error to capture the error
             Mock Write-Error
+        }
 
-
+        It 'Should log an error and return nothing when ping fails' {
             $ComputerName = 'RemotePC'
 
             $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
@@ -506,140 +268,6 @@ Describe 'Get-UserProfilesFromRegistry' -Tags 'Unit' {
             $result | Should -BeNullOrEmpty
             Assert-MockCalled Test-ComputerPing -Exactly 1
             Assert-MockCalled Write-Error -Exactly 1
-            Assert-MockCalled Get-SIDProfileInfo -Exactly 0
-        }
-    }
-
-    Context 'When user has administrator privileges' {
-        BeforeEach {
-            InModuleScope -ScriptBlock {
-                # Mock admin environment variable
-                $ENV:WinProfileOps_IsAdmin = $true
-
-                # Mock Get-SIDProfileInfo to return a list of profiles
-                Mock Get-SIDProfileInfo {
-                    return @(
-                        [PSCustomObject]@{ SID = 'S-1-5-21-1001'; ProfilePath = 'C:\Users\User1' },
-                        [PSCustomObject]@{ SID = 'S-1-5-21-1002'; ProfilePath = 'C:\Users\User2' }
-                    )
-                }
-            }
-        }
-
-        It 'Should use registry-based method when user has admin privileges' {
-            $ComputerName = $env:COMPUTERNAME
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # Validate result
-            $result | Should -HaveCount 2
-            $result[0].SID | Should -Be 'S-1-5-21-1001'
-            $result[0].ProfilePath | Should -Be 'C:\Users\User1'
-            $result[1].SID | Should -Be 'S-1-5-21-1002'
-            $result[1].ProfilePath | Should -Be 'C:\Users\User2'
-
-            # Assert that Get-SIDProfileInfo was called
-            Assert-MockCalled Get-SIDProfileInfo -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
-        }
-    }
-
-    # Test for profiles when the user does not have admin privileges
-    Context 'When user lacks administrator privileges' {
-        BeforeEach {
-            InModuleScope -ScriptBlock {
-                # Mock non-admin environment variable
-                $ENV:WinProfileOps_IsAdmin = $false
-
-                # Mock Get-SIDProfileInfoFallback to return a list of profiles
-                Mock Get-SIDProfileInfoFallback {
-                    return @(
-                        [PSCustomObject]@{ SID = 'S-1-5-21-2001'; ProfilePath = 'C:\Users\User1' },
-                        [PSCustomObject]@{ SID = 'S-1-5-21-2002'; ProfilePath = 'C:\Users\User2' }
-                    )
-                }
-            }
-        }
-
-        It 'Should use fallback method when user lacks admin privileges' {
-            $ComputerName = $env:COMPUTERNAME
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # Validate result
-            $result | Should -HaveCount 2
-            $result[0].SID | Should -Be 'S-1-5-21-2001'
-            $result[0].ProfilePath | Should -Be 'C:\Users\User1'
-            $result[1].SID | Should -Be 'S-1-5-21-2002'
-            $result[1].ProfilePath | Should -Be 'C:\Users\User2'
-
-            # Assert that Get-SIDProfileInfoFallback was called
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
-        }
-    }
-
-    # Test when Get-SIDProfileInfoFallback fails
-    Context 'When Get-SIDProfileInfoFallback fails' {
-        BeforeEach {
-            InModuleScope -ScriptBlock {
-                # Mock non-admin environment variable
-                $ENV:WinProfileOps_IsAdmin = $false
-
-                # Mock Get-SIDProfileInfoFallback to simulate an error
-                Mock Get-SIDProfileInfoFallback {
-                    throw "Failed to retrieve profiles via fallback method"
-                }
-
-                # Mock Write-Error to capture the error
-                Mock Write-Error
-            }
-        }
-
-        It 'Should log an error and return nothing when fallback method fails' {
-            $ComputerName = $env:COMPUTERNAME
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # The result should be empty
-            $result | Should -BeNullOrEmpty
-            # Assert that Write-Error was called
-            Assert-MockCalled Write-Error -Exactly 1
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 1
-            Assert-MockCalled Test-ComputerPing -Exactly 1 -Scope It
-        }
-    }
-
-    # Test for when the computer is unreachable
-    Context 'When the computer is unreachable' {
-        BeforeEach {
-            InModuleScope -ScriptBlock {
-                # Mock Test-ComputerPing to simulate the computer being unreachable
-                Mock Test-ComputerPing {
-                    return $false
-                }
-
-                # Mock Write-Warning to capture the warning
-                Mock Write-Warning
-
-                Mock Get-SIDProfileInfoFallback
-
-                Mock Get-SIDProfileInfo
-            }
-        }
-
-        It 'Should log a warning and return nothing when the computer is unreachable' {
-            $ComputerName = 'OfflinePC'
-
-            $result = Get-UserProfilesFromRegistry -ComputerName $ComputerName
-
-            # The result should be empty
-            $result | Should -BeNullOrEmpty
-
-            # Assert that Test-ComputerPing and Write-Warning were called
-            Assert-MockCalled Test-ComputerPing -Exactly 1
-            Assert-MockCalled Write-Warning -Exactly 1
-            Assert-MockCalled Get-SIDProfileInfoFallback -Exactly 0
             Assert-MockCalled Get-SIDProfileInfo -Exactly 0
         }
     }


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Improved objects returned for 'access denied' scenarios when testing if the folding exists 

### Changed

- Refactored `Process-RegistryProfiles` to better account for access denied errors
when testing profile paths with `Test-FolderExists`

- Updated `UserProfile` object creation in `Test-OrphanedProfile` for
 `$AccessError` Scenarios

- Module is now using `WinRegOps` Version `0.4.0` for more refined registry value
retrieval