### PR TITLE
changed `Get-SIDFromUsername` to use .net class for resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ from the Windows registry based on SIDs, Usernames, or UserProfile objects.
 - The module is now using `WinRegOps` version `0.4.0` for more refined registry
  value retrieval.
 
+- Refactored `Get-SIDFromUsername` to use `.NET` classes
+ (`System.Security.Principal.NTAccount` and `System.Security.Principal.SecurityIdentifier`)
+  instead of relying on `Get-CimInstance` for SID resolution.
+
 ## [0.2.0] - 2024-09-12
 
 ### Added

--- a/source/Private/RemoveProfileReg/Resolve-UsernamesToSIDs.ps1
+++ b/source/Private/RemoveProfileReg/Resolve-UsernamesToSIDs.ps1
@@ -3,42 +3,40 @@
 Resolves a list of usernames to their corresponding Security Identifiers (SIDs).
 
 .DESCRIPTION
-The `Resolve-UsernamesToSIDs` function resolves each provided username to its corresponding SID on the specified computer. If a username cannot be resolved, a warning is logged.
+The `Resolve-UsernamesToSIDs` function resolves each provided username to its corresponding Security Identifier (SID) using the .NET `System.Security.Principal.NTAccount` class. For each username in the input array, the function attempts to resolve the username locally. If a username cannot be resolved, a warning is logged, and the function continues processing the next username.
 
 .PARAMETER Usernames
-Specifies an array of usernames to resolve to SIDs.
-
-.PARAMETER ComputerName
-Specifies the name of the computer on which to resolve the usernames.
+Specifies an array of usernames to resolve to SIDs. This parameter is mandatory.
 
 .EXAMPLE
-Resolve-UsernamesToSIDs -Usernames 'user1', 'user2' -ComputerName 'Server01'
+Resolve-UsernamesToSIDs -Usernames 'user1', 'user2'
 
 Description:
-Resolves the SIDs for 'user1' and 'user2' on Server01.
+Resolves the SIDs for 'user1' and 'user2' on the local computer.
 
 .OUTPUTS
-Array of SIDs corresponding to the provided usernames.
-#>
+Array of SIDs corresponding to the provided usernames. If a username cannot be resolved, it will not be included in the output array, and a warning will be logged.
 
+.NOTES
+This function uses the `Get-SIDFromUsername` function, which internally uses the .NET `System.Security.Principal.NTAccount` class for resolving SIDs. It does not support resolving SIDs from remote computers and works only on the local system.
+#>
 function Resolve-UsernamesToSIDs
 {
     param (
-        [string[]]$Usernames,
-        [string]$ComputerName
+        [string[]]$Usernames
     )
 
     $SIDs = @()
     foreach ($Username in $Usernames)
     {
-        $SID = Get-SIDFromUsername -Username $Username -ComputerName $ComputerName
+        $SID = Get-SIDFromUsername -Username $Username
         if ($SID)
         {
             $SIDs += $SID
         }
         else
         {
-            Write-Warning "Could not resolve SID for username $Username on $ComputerName."
+            Write-Warning "Could not resolve SID for username $Username."
         }
     }
     return $SIDs

--- a/source/Public/Remove-UserProfilesFromRegistry.ps1
+++ b/source/Public/Remove-UserProfilesFromRegistry.ps1
@@ -90,7 +90,7 @@ function Remove-UserProfilesFromRegistry
         # Resolve SIDs if Usernames are provided
         if ($PSCmdlet.ParameterSetName -eq 'UserNameSet')
         {
-            $SIDs = Resolve-UsernamesToSIDs -Usernames $Usernames -ComputerName $ComputerName
+            $SIDs = Resolve-UsernamesToSIDs -Usernames $Usernames
 
             # If no SIDs were resolved, return early
             if (-not $SIDs)

--- a/tests/Unit/Private/Helpers/Get-SIDFromUsername.tests.ps1
+++ b/tests/Unit/Private/Helpers/Get-SIDFromUsername.tests.ps1
@@ -17,24 +17,22 @@ AfterAll {
     Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
 }
 
-Describe 'Get-SIDFromUsername' -Tags "Pivate", "Helpers" {
-    # Mock the Get-CimInstance cmdlet to simulate different scenarios
+Describe 'Get-SIDFromUsername' -Tags "Private", "Helpers" {
 
     Context 'When the username exists and has a valid SID' {
         It 'should return the correct SID' {
 
             InModuleScope -ScriptBlock {
 
-                $ComputerName = 'Server01'
-                # Mock Get-CimInstance to return a valid SID
-                Mock -CommandName Get-CimInstance -MockWith {
-                    @{
-                        SID = 'S-1-5-21-1234567890-1234567890-1234567890-1001'
+                # Mock NTAccount and SecurityIdentifier
+                Mock -CommandName New-Object -MockWith {
+                    New-MockObject -Type 'System.Security.Principal.NTAccount' -Methods @{
+                        Translate = { New-MockObject -Type 'System.Security.Principal.SecurityIdentifier' -Properties @{ Value = 'S-1-5-21-1234567890-1234567890-1234567890-1001' } }
                     }
                 }
 
                 # Act: Call the function
-                $result = Get-SIDFromUsername -Username 'JohnDoe' -ComputerName $ComputerName
+                $result = Get-SIDFromUsername -Username 'JohnDoe'
 
                 # Assert: Verify the result is the correct SID
                 $result | Should -Be 'S-1-5-21-1234567890-1234567890-1234567890-1001'
@@ -46,16 +44,17 @@ Describe 'Get-SIDFromUsername' -Tags "Pivate", "Helpers" {
         It 'should return null and show a warning' {
 
             InModuleScope -ScriptBlock {
-                $ComputerName = 'Server01'
 
-                # Mock Get-CimInstance to return null (user not found)
-                Mock -CommandName Get-CimInstance -MockWith { $null }
+                # Mock NTAccount to throw an error (user not found)
+                Mock -CommandName New-Object -MockWith {
+                    throw [System.Security.Principal.IdentityNotMappedException]::new("User not found")
+                }
 
                 # Mock Write-Warning to capture the warning message
                 Mock -CommandName Write-Warning
 
                 # Act: Call the function
-                $result = Get-SIDFromUsername -Username 'NonExistentUser' -ComputerName $ComputerName
+                $result = Get-SIDFromUsername -Username 'NonExistentUser'
 
                 # Assert: The result should be null
                 $result | Should -BeNullOrEmpty
@@ -66,60 +65,27 @@ Describe 'Get-SIDFromUsername' -Tags "Pivate", "Helpers" {
         }
     }
 
-    Context 'When an error occurs while querying' {
+    Context 'When an error occurs while resolving the username' {
         It 'should return null and display a warning with error information' {
 
             InModuleScope -ScriptBlock {
-                $ComputerName = 'Server01'
 
-                # Mock Get-CimInstance to throw an exception
-                Mock -CommandName Get-CimInstance -MockWith { throw "WMI query failed" }
+                # Mock NTAccount to throw a general exception
+                Mock -CommandName New-Object -MockWith {
+                    throw "An unexpected error occurred"
+                }
 
                 # Mock Write-Warning to capture the warning message
                 Mock -CommandName Write-Warning
 
                 # Act: Call the function
-                $result = Get-SIDFromUsername -Username 'JohnDoe' -ComputerName $ComputerName
+                $result = Get-SIDFromUsername -Username 'JohnDoe'
 
                 # Assert: The result should be null
                 $result | Should -BeNullOrEmpty
 
                 # Assert: Verify that the warning message was displayed
                 Assert-MockCalled -CommandName Write-Warning -Exactly 1 -Scope It
-
-            }
-        }
-    }
-
-    Context 'When mandatory parameters are missing' {
-        It 'should throw a missing parameter error for Username' {
-
-            InModuleScope -ScriptBlock {
-
-                $ComputerName = 'Server01'
-                # Act & Assert: Expecting the function to throw an error
-                { Get-SIDFromUsername -Username $Null -ComputerName $ComputerName } | Should -Throw
-
-            }
-        }
-
-        It 'should default to localhost when ComputerName is missing' {
-            InModuleScope -ScriptBlock {
-                # Mock Get-CimInstance to return a valid SID when queried with 'localhost'
-                Mock -CommandName Get-CimInstance -MockWith {
-                    @{
-                        SID = 'S-1-5-21-1234567890-1234567890-1234567890-1001'
-                    }
-                }
-
-                # Act: Call the function without providing ComputerName
-                $result = Get-SIDFromUsername -Username 'JohnDoe'
-
-                # Assert: The result should match the mock SID
-                $result | Should -Be 'S-1-5-21-1234567890-1234567890-1234567890-1001'
-
-                # Assert: Ensure Get-CimInstance was called with 'localhost'
-                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter { $ComputerName -eq $env:COMPUTERNAME } -Scope It
             }
         }
     }
@@ -129,28 +95,24 @@ Describe 'Get-SIDFromUsername' -Tags "Pivate", "Helpers" {
 
             InModuleScope -ScriptBlock {
 
-
-                # Mock Get-CimInstance to return an object without SID
-                Mock -CommandName Get-CimInstance -MockWith {
-                    @{
-                        SID = $null
+                # Mock NTAccount to return null for SID
+                Mock -CommandName New-Object -MockWith {
+                    New-MockObject -Type 'System.Security.Principal.NTAccount' -Methods @{
+                        Translate = { $null }
                     }
                 }
 
                 # Mock Write-Warning to capture the warning message
                 Mock -CommandName Write-Warning
 
-                $computerName = 'Server01'
-
                 # Act: Call the function
-                $result = Get-SIDFromUsername -Username 'JohnDoe' -ComputerName $computerName
+                $result = Get-SIDFromUsername -Username 'JohnDoe'
 
                 # Assert: The result should be null
                 $result | Should -BeNullOrEmpty
 
                 # Assert: Verify that the warning message was displayed
                 Assert-MockCalled -CommandName Write-Warning -Exactly 1 -Scope It
-
             }
         }
     }

--- a/tests/Unit/Private/RemoveProfileReg/Resolve-UsernamesToSIDs.tests.ps1
+++ b/tests/Unit/Private/RemoveProfileReg/Resolve-UsernamesToSIDs.tests.ps1
@@ -33,22 +33,22 @@ Describe 'Resolve-UsernamesToSIDs' -Tags 'Private', 'RemoveProfileReg' {
             InModuleScope -ScriptBlock {
                 # Mock Get-SIDFromUsername to return valid SIDs
                 Mock Get-SIDFromUsername {
-                    param($Username, $ComputerName)
+                    param($Username)
                     switch ($Username)
                     {
                         'user1'
                         {
-                            return 'S-1-5-21-1001'
+                            return 'S-1-5-21-1001' 
                         }
                         'user2'
                         {
-                            return 'S-1-5-21-1002'
+                            return 'S-1-5-21-1002' 
                         }
                     }
                 }
 
                 # Call the function with valid usernames
-                $result = Resolve-UsernamesToSIDs -Usernames 'user1', 'user2' -ComputerName 'Server01'
+                $result = Resolve-UsernamesToSIDs -Usernames 'user1', 'user2'
 
                 # Validate that the returned array contains the correct SIDs
                 $result | Should -Be @('S-1-5-21-1001', 'S-1-5-21-1002')
@@ -65,29 +65,29 @@ Describe 'Resolve-UsernamesToSIDs' -Tags 'Private', 'RemoveProfileReg' {
             InModuleScope -ScriptBlock {
                 # Mock Get-SIDFromUsername to return SIDs for some usernames and $null for others
                 Mock Get-SIDFromUsername {
-                    param($Username, $ComputerName)
+                    param($Username)
                     switch ($Username)
                     {
                         'user1'
                         {
-                            return 'S-1-5-21-1001'
+                            return 'S-1-5-21-1001' 
                         }
                         'invalidUser'
                         {
-                            return $null
+                            return $null 
                         }
                     }
                 }
 
                 # Call the function with a mix of valid and invalid usernames
-                $result = Resolve-UsernamesToSIDs -Usernames 'user1', 'invalidUser' -ComputerName 'Server01'
+                $result = Resolve-UsernamesToSIDs -Usernames 'user1', 'invalidUser'
 
                 # Validate that the returned array contains only the valid SID
                 $result | Should -Be @('S-1-5-21-1001')
 
                 # Ensure that Write-Warning was called for the unresolved username
                 Assert-MockCalled Write-Warning -Exactly 1 -Scope It -ParameterFilter {
-                    $Message -eq 'Could not resolve SID for username invalidUser on Server01.'
+                    $Message -eq 'Could not resolve SID for username invalidUser.'
                 }
             }
         }
@@ -98,7 +98,7 @@ Describe 'Resolve-UsernamesToSIDs' -Tags 'Private', 'RemoveProfileReg' {
         It 'Should return an empty array' {
             InModuleScope -ScriptBlock {
                 # Call the function with an empty array of usernames
-                $result = Resolve-UsernamesToSIDs -Usernames @() -ComputerName 'Server01'
+                $result = Resolve-UsernamesToSIDs -Usernames @()
 
                 # Validate that the result is an empty array
                 $result | Should -Be @()
@@ -116,26 +116,26 @@ Describe 'Resolve-UsernamesToSIDs' -Tags 'Private', 'RemoveProfileReg' {
             InModuleScope -ScriptBlock {
                 # Mock Get-SIDFromUsername to return SIDs for multiple usernames
                 Mock Get-SIDFromUsername {
-                    param($Username, $ComputerName)
+                    param($Username)
                     switch ($Username)
                     {
                         'user1'
                         {
-                            return 'S-1-5-21-1001'
+                            return 'S-1-5-21-1001' 
                         }
                         'user2'
                         {
-                            return 'S-1-5-21-1002'
+                            return 'S-1-5-21-1002' 
                         }
                         'user3'
                         {
-                            return 'S-1-5-21-1003'
+                            return 'S-1-5-21-1003' 
                         }
                     }
                 }
 
                 # Call the function with multiple usernames
-                $result = Resolve-UsernamesToSIDs -Usernames 'user1', 'user2', 'user3' -ComputerName 'Server01'
+                $result = Resolve-UsernamesToSIDs -Usernames 'user1', 'user2', 'user3'
 
                 # Validate that the returned array contains the correct SIDs
                 $result | Should -Be @('S-1-5-21-1001', 'S-1-5-21-1002', 'S-1-5-21-1003')
@@ -156,14 +156,14 @@ Describe 'Resolve-UsernamesToSIDs' -Tags 'Private', 'RemoveProfileReg' {
                 }
 
                 # Call the function with an unresolved username
-                $result = Resolve-UsernamesToSIDs -Usernames 'invalidUser' -ComputerName 'Server01'
+                $result = Resolve-UsernamesToSIDs -Usernames 'invalidUser'
 
                 # Validate that the result is an empty array
                 $result | Should -Be @()
 
                 # Ensure that Write-Warning was called with the correct message
                 Assert-MockCalled Write-Warning -Exactly 1 -Scope It -ParameterFilter {
-                    $Message -eq 'Could not resolve SID for username invalidUser on Server01.'
+                    $Message -eq 'Could not resolve SID for username invalidUser.'
                 }
             }
         }

--- a/tests/Unit/Public/Remove-UserProfilesFromRegistry.tests.ps1
+++ b/tests/Unit/Public/Remove-UserProfilesFromRegistry.tests.ps1
@@ -65,7 +65,7 @@ Describe 'Remove-UserProfilesFromRegistry'  -Tag 'Public' {
                 param($Usernames, $ComputerName)
 
                 $SIDs = $Usernames | ForEach-Object {
-                    Get-SIDFromUsername -Username $_ -ComputerName $ComputerName
+                    Get-SIDFromUsername -Username $_ 
                 }
 
                 return $SIDs


### PR DESCRIPTION
# Pull Request


## Pull Request (PR) description
### Changed
- Refactored `Get-SIDFromUsername` to use `.NET` classes
 (`System.Security.Principal.NTAccount` and `System.Security.Principal.SecurityIdentifier`)
  instead of relying on `Get-CimInstance` for SID resolution.
